### PR TITLE
Fixed a ViewGroup constructors for an old Android version

### DIFF
--- a/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundLinearLayout.java
+++ b/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundLinearLayout.java
@@ -41,12 +41,19 @@ public class ForegroundLinearLayout extends LinearLayout {
     }
 
     public ForegroundLinearLayout(Context context, AttributeSet attrs, int defStyle) {
-        this(context, attrs, defStyle, 0);
+        super(context, attrs, defStyle);
+
+        init(context, attrs, defStyle, 0);
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public ForegroundLinearLayout(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
+
+        init(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    private void init(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             mForegroundDelegate = new ForegroundDelegate(this);
             mForegroundDelegate.init(context, attrs, defStyleAttr, defStyleRes);

--- a/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundRelativeLayout.java
+++ b/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundRelativeLayout.java
@@ -41,12 +41,19 @@ public class ForegroundRelativeLayout extends RelativeLayout {
     }
 
     public ForegroundRelativeLayout(Context context, AttributeSet attrs, int defStyle) {
-        this(context, attrs, defStyle, 0);
+        super(context, attrs, defStyle);
+
+        init(context, attrs, defStyle, 0);
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public ForegroundRelativeLayout(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
+
+        init(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    private void init(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             mForegroundDelegate = new ForegroundDelegate(this);
             mForegroundDelegate.init(context, attrs, defStyleAttr, defStyleRes);


### PR DESCRIPTION
Hi, i have fixed pre-lollipop constructors for LinearLayout and RelativeLayout to have ability to use it on Android below 5.0
