### PR TITLE
Fix working ForegroundDelegate on API 23 devices with targetVersion 22 in Gradle.

### DIFF
--- a/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundButton.java
+++ b/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundButton.java
@@ -42,7 +42,7 @@ public class ForegroundButton extends AppCompatButton {
     public ForegroundButton(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M || getContext().getApplicationInfo().targetSdkVersion < Build.VERSION_CODES.M) {
             mForegroundDelegate = new ForegroundDelegate(this);
             mForegroundDelegate.init(context, attrs, defStyle, 0);
         }
@@ -50,24 +50,25 @@ public class ForegroundButton extends AppCompatButton {
 
     @Override
     public int getForegroundGravity() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
+            return mForegroundDelegate.getForegroundGravity();
+        } else {
             return super.getForegroundGravity();
         }
-        return mForegroundDelegate.getForegroundGravity();
     }
 
     @Override
     public void setForegroundGravity(int foregroundGravity) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            super.setForegroundGravity(foregroundGravity);
-        } else {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.setForegroundGravity(foregroundGravity);
+        } else {
+            super.setForegroundGravity(foregroundGravity);
         }
     }
 
     @Override
     protected boolean verifyDrawable(Drawable who) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             return super.verifyDrawable(who) || (who == mForegroundDelegate.getForeground());
         } else {
             return super.verifyDrawable(who);
@@ -77,7 +78,7 @@ public class ForegroundButton extends AppCompatButton {
     @Override
     public void jumpDrawablesToCurrentState() {
         super.jumpDrawablesToCurrentState();
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.jumpDrawablesToCurrentState();
         }
     }
@@ -85,7 +86,7 @@ public class ForegroundButton extends AppCompatButton {
     @Override
     protected void drawableStateChanged() {
         super.drawableStateChanged();
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.drawableStateChanged();
         }
     }
@@ -93,26 +94,26 @@ public class ForegroundButton extends AppCompatButton {
 
     @Override
     public void setForeground(Drawable foreground) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            super.setForeground(foreground);
-        } else {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.setForeground(foreground);
+        } else {
+            super.setForeground(foreground);
         }
     }
 
     @Override
     public Drawable getForeground() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            return super.getForeground();
-        } else {
+        if (mForegroundDelegate != null) {
             return mForegroundDelegate.getForeground();
+        } else {
+            return super.getForeground();
         }
     }
 
     @Override
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.onLayout(changed, left, top, right, bottom);
         }
     }
@@ -120,7 +121,7 @@ public class ForegroundButton extends AppCompatButton {
     @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
         super.onSizeChanged(w, h, oldw, oldh);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.onSizeChanged(w, h, oldw, oldh);
         }
     }
@@ -128,7 +129,7 @@ public class ForegroundButton extends AppCompatButton {
     @Override
     public void draw(Canvas canvas) {
         super.draw(canvas);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.draw(canvas);
         }
     }
@@ -136,7 +137,7 @@ public class ForegroundButton extends AppCompatButton {
     @Override
     public void drawableHotspotChanged(float x, float y) {
         super.drawableHotspotChanged(x, y);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.drawableHotspotChanged(x, y);
         }
     }

--- a/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundImageView.java
+++ b/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundImageView.java
@@ -42,7 +42,7 @@ public class ForegroundImageView extends AppCompatImageView {
     public ForegroundImageView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M || getContext().getApplicationInfo().targetSdkVersion < Build.VERSION_CODES.M) {
             mForegroundDelegate = new ForegroundDelegate(this);
             mForegroundDelegate.init(context, attrs, defStyle, 0);
         }
@@ -50,24 +50,25 @@ public class ForegroundImageView extends AppCompatImageView {
 
     @Override
     public int getForegroundGravity() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
+            return mForegroundDelegate.getForegroundGravity();
+        } else {
             return super.getForegroundGravity();
         }
-        return mForegroundDelegate.getForegroundGravity();
     }
 
     @Override
     public void setForegroundGravity(int foregroundGravity) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            super.setForegroundGravity(foregroundGravity);
-        } else {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.setForegroundGravity(foregroundGravity);
+        } else {
+            super.setForegroundGravity(foregroundGravity);
         }
     }
 
     @Override
     protected boolean verifyDrawable(Drawable who) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             return super.verifyDrawable(who) || (who == mForegroundDelegate.getForeground());
         } else {
             return super.verifyDrawable(who);
@@ -77,7 +78,7 @@ public class ForegroundImageView extends AppCompatImageView {
     @Override
     public void jumpDrawablesToCurrentState() {
         super.jumpDrawablesToCurrentState();
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.jumpDrawablesToCurrentState();
         }
     }
@@ -85,7 +86,7 @@ public class ForegroundImageView extends AppCompatImageView {
     @Override
     protected void drawableStateChanged() {
         super.drawableStateChanged();
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.drawableStateChanged();
         }
     }
@@ -93,26 +94,26 @@ public class ForegroundImageView extends AppCompatImageView {
 
     @Override
     public void setForeground(Drawable foreground) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            super.setForeground(foreground);
-        } else {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.setForeground(foreground);
+        } else {
+            super.setForeground(foreground);
         }
     }
 
     @Override
     public Drawable getForeground() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            return super.getForeground();
-        } else {
+        if (mForegroundDelegate != null) {
             return mForegroundDelegate.getForeground();
+        } else {
+            return super.getForeground();
         }
     }
 
     @Override
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.onLayout(changed, left, top, right, bottom);
         }
     }
@@ -120,7 +121,7 @@ public class ForegroundImageView extends AppCompatImageView {
     @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
         super.onSizeChanged(w, h, oldw, oldh);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.onSizeChanged(w, h, oldw, oldh);
         }
     }
@@ -128,7 +129,7 @@ public class ForegroundImageView extends AppCompatImageView {
     @Override
     public void draw(Canvas canvas) {
         super.draw(canvas);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.draw(canvas);
         }
     }
@@ -136,7 +137,7 @@ public class ForegroundImageView extends AppCompatImageView {
     @Override
     public void drawableHotspotChanged(float x, float y) {
         super.drawableHotspotChanged(x, y);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.drawableHotspotChanged(x, y);
         }
     }

--- a/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundLinearLayout.java
+++ b/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundLinearLayout.java
@@ -19,16 +19,15 @@
 
 package com.commit451.foregroundviews;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.support.v7.widget.LinearLayoutCompat;
 import android.util.AttributeSet;
-import android.widget.LinearLayout;
 
 
-public class ForegroundLinearLayout extends LinearLayout {
+public class ForegroundLinearLayout extends LinearLayoutCompat {
 
     ForegroundDelegate mForegroundDelegate;
 
@@ -46,15 +45,8 @@ public class ForegroundLinearLayout extends LinearLayout {
         init(context, attrs, defStyle, 0);
     }
 
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    public ForegroundLinearLayout(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
-        super(context, attrs, defStyleAttr, defStyleRes);
-
-        init(context, attrs, defStyleAttr, defStyleRes);
-    }
-
     private void init(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M || getContext().getApplicationInfo().targetSdkVersion < Build.VERSION_CODES.M) {
             mForegroundDelegate = new ForegroundDelegate(this);
             mForegroundDelegate.init(context, attrs, defStyleAttr, defStyleRes);
         }
@@ -62,24 +54,25 @@ public class ForegroundLinearLayout extends LinearLayout {
 
     @Override
     public int getForegroundGravity() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
+            return mForegroundDelegate.getForegroundGravity();
+        } else {
             return super.getForegroundGravity();
         }
-        return mForegroundDelegate.getForegroundGravity();
     }
 
     @Override
     public void setForegroundGravity(int foregroundGravity) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            super.setForegroundGravity(foregroundGravity);
-        } else {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.setForegroundGravity(foregroundGravity);
+        } else {
+            super.setForegroundGravity(foregroundGravity);
         }
     }
 
     @Override
     protected boolean verifyDrawable(Drawable who) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             return super.verifyDrawable(who) || (who == mForegroundDelegate.getForeground());
         } else {
             return super.verifyDrawable(who);
@@ -89,7 +82,7 @@ public class ForegroundLinearLayout extends LinearLayout {
     @Override
     public void jumpDrawablesToCurrentState() {
         super.jumpDrawablesToCurrentState();
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.jumpDrawablesToCurrentState();
         }
     }
@@ -97,7 +90,7 @@ public class ForegroundLinearLayout extends LinearLayout {
     @Override
     protected void drawableStateChanged() {
         super.drawableStateChanged();
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.drawableStateChanged();
         }
     }
@@ -105,26 +98,26 @@ public class ForegroundLinearLayout extends LinearLayout {
 
     @Override
     public void setForeground(Drawable foreground) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            super.setForeground(foreground);
-        } else {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.setForeground(foreground);
+        } else {
+            super.setForeground(foreground);
         }
     }
 
     @Override
     public Drawable getForeground() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            return super.getForeground();
-        } else {
+        if (mForegroundDelegate != null) {
             return mForegroundDelegate.getForeground();
+        } else {
+            return super.getForeground();
         }
     }
 
     @Override
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.onLayout(changed, left, top, right, bottom);
         }
     }
@@ -132,7 +125,7 @@ public class ForegroundLinearLayout extends LinearLayout {
     @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
         super.onSizeChanged(w, h, oldw, oldh);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.onSizeChanged(w, h, oldw, oldh);
         }
     }
@@ -140,7 +133,7 @@ public class ForegroundLinearLayout extends LinearLayout {
     @Override
     public void draw(Canvas canvas) {
         super.draw(canvas);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.draw(canvas);
         }
     }
@@ -148,7 +141,7 @@ public class ForegroundLinearLayout extends LinearLayout {
     @Override
     public void drawableHotspotChanged(float x, float y) {
         super.drawableHotspotChanged(x, y);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.drawableHotspotChanged(x, y);
         }
     }

--- a/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundRelativeLayout.java
+++ b/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundRelativeLayout.java
@@ -19,7 +19,6 @@
 
 package com.commit451.foregroundviews;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
@@ -42,19 +41,11 @@ public class ForegroundRelativeLayout extends RelativeLayout {
 
     public ForegroundRelativeLayout(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
-
         init(context, attrs, defStyle, 0);
     }
 
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    public ForegroundRelativeLayout(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
-        super(context, attrs, defStyleAttr, defStyleRes);
-
-        init(context, attrs, defStyleAttr, defStyleRes);
-    }
-
     private void init(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M || getContext().getApplicationInfo().targetSdkVersion < Build.VERSION_CODES.M) {
             mForegroundDelegate = new ForegroundDelegate(this);
             mForegroundDelegate.init(context, attrs, defStyleAttr, defStyleRes);
         }
@@ -62,24 +53,25 @@ public class ForegroundRelativeLayout extends RelativeLayout {
 
     @Override
     public int getForegroundGravity() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
+            return mForegroundDelegate.getForegroundGravity();
+        } else {
             return super.getForegroundGravity();
         }
-        return mForegroundDelegate.getForegroundGravity();
     }
 
     @Override
     public void setForegroundGravity(int foregroundGravity) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            super.setForegroundGravity(foregroundGravity);
-        } else {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.setForegroundGravity(foregroundGravity);
+        } else {
+            super.setForegroundGravity(foregroundGravity);
         }
     }
 
     @Override
     protected boolean verifyDrawable(Drawable who) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             return super.verifyDrawable(who) || (who == mForegroundDelegate.getForeground());
         } else {
             return super.verifyDrawable(who);
@@ -89,7 +81,7 @@ public class ForegroundRelativeLayout extends RelativeLayout {
     @Override
     public void jumpDrawablesToCurrentState() {
         super.jumpDrawablesToCurrentState();
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.jumpDrawablesToCurrentState();
         }
     }
@@ -97,7 +89,7 @@ public class ForegroundRelativeLayout extends RelativeLayout {
     @Override
     protected void drawableStateChanged() {
         super.drawableStateChanged();
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.drawableStateChanged();
         }
     }
@@ -105,26 +97,26 @@ public class ForegroundRelativeLayout extends RelativeLayout {
 
     @Override
     public void setForeground(Drawable foreground) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            super.setForeground(foreground);
-        } else {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.setForeground(foreground);
+        } else {
+            super.setForeground(foreground);
         }
     }
 
     @Override
     public Drawable getForeground() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            return super.getForeground();
-        } else {
+        if (mForegroundDelegate != null) {
             return mForegroundDelegate.getForeground();
+        } else {
+            return super.getForeground();
         }
     }
 
     @Override
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.onLayout(changed, left, top, right, bottom);
         }
     }
@@ -132,7 +124,7 @@ public class ForegroundRelativeLayout extends RelativeLayout {
     @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
         super.onSizeChanged(w, h, oldw, oldh);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.onSizeChanged(w, h, oldw, oldh);
         }
     }
@@ -140,7 +132,7 @@ public class ForegroundRelativeLayout extends RelativeLayout {
     @Override
     public void draw(Canvas canvas) {
         super.draw(canvas);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.draw(canvas);
         }
     }
@@ -148,7 +140,7 @@ public class ForegroundRelativeLayout extends RelativeLayout {
     @Override
     public void drawableHotspotChanged(float x, float y) {
         super.drawableHotspotChanged(x, y);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (mForegroundDelegate != null) {
             mForegroundDelegate.drawableHotspotChanged(x, y);
         }
     }


### PR DESCRIPTION
Hi, i faced the problem. You can check it in android.view.View on lines 4279, 4384 etc.
there checking code:
if (targetSdkVersion >= VERSION_CODES.M || this instanceof FrameLayout) {}
it turns out that not will be working with API 23 if Gradle project configured with targetVersion 22 and run app on API 23.
