### PR TITLE
remove onLayout method

### DIFF
--- a/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundButton.java
+++ b/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundButton.java
@@ -112,14 +112,6 @@ public class ForegroundButton extends AppCompatButton {
     }
 
     @Override
-    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
-        super.onLayout(changed, left, top, right, bottom);
-        if (mForegroundDelegate != null) {
-            mForegroundDelegate.onLayout(changed, left, top, right, bottom);
-        }
-    }
-
-    @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
         super.onSizeChanged(w, h, oldw, oldh);
         if (mForegroundDelegate != null) {

--- a/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundDelegate.java
+++ b/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundDelegate.java
@@ -49,10 +49,6 @@ public class ForegroundDelegate {
         }
     }
 
-    public void onLayout(boolean changed, int left, int top, int right, int bottom) {
-        mForegroundBoundsChanged = changed;
-    }
-
     public void onSizeChanged(int w, int h, int oldw, int oldh) {
         mForegroundBoundsChanged = true;
     }

--- a/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundImageView.java
+++ b/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundImageView.java
@@ -112,14 +112,6 @@ public class ForegroundImageView extends AppCompatImageView {
     }
 
     @Override
-    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
-        super.onLayout(changed, left, top, right, bottom);
-        if (mForegroundDelegate != null) {
-            mForegroundDelegate.onLayout(changed, left, top, right, bottom);
-        }
-    }
-
-    @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
         super.onSizeChanged(w, h, oldw, oldh);
         if (mForegroundDelegate != null) {

--- a/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundLinearLayout.java
+++ b/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundLinearLayout.java
@@ -122,14 +122,6 @@ public class ForegroundLinearLayout extends LinearLayout {
     }
 
     @Override
-    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
-        super.onLayout(changed, left, top, right, bottom);
-        if (mForegroundDelegate != null) {
-            mForegroundDelegate.onLayout(changed, left, top, right, bottom);
-        }
-    }
-
-    @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
         super.onSizeChanged(w, h, oldw, oldh);
         if (mForegroundDelegate != null) {

--- a/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundRelativeLayout.java
+++ b/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundRelativeLayout.java
@@ -122,14 +122,6 @@ public class ForegroundRelativeLayout extends RelativeLayout {
     }
 
     @Override
-    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
-        super.onLayout(changed, left, top, right, bottom);
-        if (mForegroundDelegate != null) {
-            mForegroundDelegate.onLayout(changed, left, top, right, bottom);
-        }
-    }
-
-    @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
         super.onSizeChanged(w, h, oldw, oldh);
         if (mForegroundDelegate != null) {

--- a/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundTextView.java
+++ b/foregroundviews/src/main/java/com/commit451/foregroundviews/ForegroundTextView.java
@@ -112,14 +112,6 @@ public class ForegroundTextView extends AppCompatTextView {
     }
 
     @Override
-    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
-        super.onLayout(changed, left, top, right, bottom);
-        if (mForegroundDelegate != null) {
-            mForegroundDelegate.onLayout(changed, left, top, right, bottom);
-        }
-    }
-
-    @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
         super.onSizeChanged(w, h, oldw, oldh);
         if (mForegroundDelegate != null) {


### PR DESCRIPTION
sometimes the methods would be called in order like this:
1. onSizeChanged() ---> mForegroundBoundsChanged : true
2. onLayout(true) ---> mForegroundBoundsChanged : true
3. onLayout(false) ---> mForegroundBoundsChanged : false

so the foregroundBounds would be (0,0,0,0) after view created, and the foregroundDrawable would not be visible.